### PR TITLE
Remove upstream person_detect_model_data as part of the sync.

### DIFF
--- a/scripts/MANIFEST.ini
+++ b/scripts/MANIFEST.ini
@@ -74,6 +74,7 @@ files =
     tensorflow/lite/micro/cortex_m_generic/debug_log.cc
     tensorflow/lite/micro/cortex_m_generic/debug_log_callback.h
     tensorflow/lite/micro/cortex_m_generic/micro_time.cc
+    third_party/person_model_int8/
     examples/
 
 #


### PR DESCRIPTION
Since the example code is going to be maintained in the Arduino repository, we are also keeping the serialized model in the current repo. As a result, we do not want to sync the model from tflite-micro.

If there is a new model then both the example and the new model can be updated manually.
