### PR TITLE
Update sync script for the new location of the models in tflite-micro

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -5,12 +5,12 @@
 # https://yaml-online-parser.appspot.com/
 #
 
-name: Sync from tflite-micro
+name: (Arduino) Sync from tflite-micro
 
 on:
   schedule:
-    # 2pm UTC is 7am or 8am PT depending on daylight savings.
-    - cron: '0 14 * * *'
+    # 10am UTC is 3am or 4am PT depending on daylight savings.
+    - cron: '0 10 * * *'
 
   # Allow manually triggering of the workflow.
   workflow_dispatch: {}
@@ -31,7 +31,7 @@ jobs:
 
       - name: Sync the code
         run: |
-          pip3 install six
+          pip3 install six Pillow
           ./scripts/sync_from_tflite_micro.sh
           git config --local user.name "TFLM-bot"
           git config --local user.email "tflm-github-bot@google.com"
@@ -50,10 +50,10 @@ jobs:
           branch: sync-from-tflite-micro
           delete-branch: true
           token: ${{ secrets.TFLM_BOT_REPO_TOKEN }}
-          title: Automated sync from github.com/tensorflow/tflite-micro
+          title: (Arduino) Automated sync from github.com/tensorflow/tflite-micro
           commit-message: Automated sync from github.com/tensorflow/tflite-micro
           committer: TFLM-bot <tflm-github-bot@google.com>
           author: TFLM-bot <tflm-github-bot@google.com>
-          body: "Automated sync from github.com/tensorflow/tflite-micro"
+          body: "(Arduino) Automated sync from github.com/tensorflow/tflite-micro"
           labels: bot:sync-tf, ci:run
           reviewers: advaitjain

--- a/scripts/MANIFEST.ini
+++ b/scripts/MANIFEST.ini
@@ -74,7 +74,7 @@ files =
     tensorflow/lite/micro/cortex_m_generic/debug_log.cc
     tensorflow/lite/micro/cortex_m_generic/debug_log_callback.h
     tensorflow/lite/micro/cortex_m_generic/micro_time.cc
-    third_party/person_model_int8/
+    tensorflow/lite/micro/models/
     examples/
 
 #


### PR DESCRIPTION
With https://github.com/tensorflow/tflite-micro/pull/337, the output tree from tflite-micro project generation has the models in the tensorflow source tree.

Since we are forking the examples for the Arduino, we are treating the corresponding models as being part of the example code (and hence need to be maintained in the Arduino repo).
