### PR TITLE
Fix audio capture sample rate bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,16 @@
-# TensorFlow Lite Micro Library for Arduino
+This repository will have the code (including examples) needed to use Tensorflow Lite Micro on an Arduino.
 
-This repository has the code (including examples) needed to use Tensorflow Lite Micro on an Arduino.
-
-## Build Status
+# Build Status
 
 Build Type          |     Status    |
 ---------------     | ------------- |
 Arduino CLI on Linux  | [![Arduino](https://github.com/tensorflow/tflite-micro-arduino-examples/actions/workflows/ci.yml/badge.svg?event=schedule)](https://github.com/tensorflow/tflite-micro-arduino-examples/actions/workflows/ci.yml)
 Sync from tflite-micro  | [![Sync from tflite-micro](https://github.com/tensorflow/tflite-micro-arduino-examples/actions/workflows/sync.yml/badge.svg)](https://github.com/tensorflow/tflite-micro-arduino-examples/actions/workflows/sync.yml)
 
-## How to Install
+# Trying out the Code
 
-### Arduino IDE
-
-The easiest way to install this library is through the Arduino's library manager.
-In the menus, go to Sketch->Include Library->Manage Libraries. This will pull
-the latest stable version.
-
-### GitHub
-
-If you want to install an in-development version of this library, you can use the
-latest version directly from this GitHub repository. This requires you clone the
-repo into the folder that holds libraries for the Arduino IDE. The location for
-this folder varies by operating system, but typically it's in
-`~/Arduino/libraries` on Linux, `~/Documents/Arduino/libraries/` on MacOS, and
-`My Documents\Arduino\Libraries` on Windows.
-
-Once you're in that folder in the terminal, you can then grab the code using the
-git command line tool:
-
-```bash
-git clone https://github.com/tensorflow/tflite-micro-arduino-examples Arduino_TensorFlowLite
-```
-
-### Checking your Installation
-
-Once the library has been installed, you should see an Arduino_TensorFlowLite
-entry in the File->Examples menu of the Arduino IDE. This submenu contains a list
-of sample projects you can try out.
+To use the latest version of the TFLM Arduino examples directly from this GitHib
+repository, you can clone the repo into `~/Arduino/libraries` and then open up the
+TFLM examples in your Arduino IDE.
 
 ![Hello World](docs/hello_world_screenshot.png)
-
-## Compatibility
-
-This library is designed for the Arduino Nano BLE Sense 33 board. The framework
-code for running machine learning models should be compatible with most Arm Cortex
-M-based boards, such as the Raspberry Pi Pico, but the code to access peripherals
-like microphones, cameras, and accelerometers is specific to the Nano.
-
-## License
-
-This code is made available under the Apache 2 license.
-
-## Contributing
-
-Forks of this library are welcome and encouraged. If you have bug reports or
-fixes to contribute, the source of this code is at [https:://github.com/tensorflow/tflite-micro](github.com/tensorflow/tflite-micro)
-and all issues and pull requests should be directed there.
-
-The code here is created through an automatic project generation process from
-that source of truth, since it's cross-platform and needs to be modified to
-work within the Arduino IDE.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,63 @@
-This repository will have the code (including examples) needed to use Tensorflow Lite Micro on an Arduino.
+# TensorFlow Lite Micro Library for Arduino
 
-# Build Status
+This repository has the code (including examples) needed to use Tensorflow Lite Micro on an Arduino.
+
+## Build Status
 
 Build Type          |     Status    |
 ---------------     | ------------- |
 Arduino CLI on Linux  | [![Arduino](https://github.com/tensorflow/tflite-micro-arduino-examples/actions/workflows/ci.yml/badge.svg?event=schedule)](https://github.com/tensorflow/tflite-micro-arduino-examples/actions/workflows/ci.yml)
 Sync from tflite-micro  | [![Sync from tflite-micro](https://github.com/tensorflow/tflite-micro-arduino-examples/actions/workflows/sync.yml/badge.svg)](https://github.com/tensorflow/tflite-micro-arduino-examples/actions/workflows/sync.yml)
 
-# Trying out the Code
+## How to Install
 
-To use the latest version of the TFLM Arduino examples directly from this GitHib
-repository, you can clone the repo into `~/Arduino/libraries` and then open up the
-TFLM examples in your Arduino IDE.
+### Arduino IDE
+
+The easiest way to install this library is through the Arduino's library manager.
+In the menus, go to Sketch->Include Library->Manage Libraries. This will pull
+the latest stable version.
+
+### GitHub
+
+If you want to install an in-development version of this library, you can use the
+latest version directly from this GitHub repository. This requires you clone the
+repo into the folder that holds libraries for the Arduino IDE. The location for
+this folder varies by operating system, but typically it's in
+`~/Arduino/libraries` on Linux, `~/Documents/Arduino/libraries/` on MacOS, and
+`My Documents\Arduino\Libraries` on Windows.
+
+Once you're in that folder in the terminal, you can then grab the code using the
+git command line tool:
+
+```bash
+git clone https://github.com/tensorflow/tflite-micro-arduino-examples Arduino_TensorFlowLite
+```
+
+### Checking your Installation
+
+Once the library has been installed, you should see an Arduino_TensorFlowLite
+entry in the File->Examples menu of the Arduino IDE. This submenu contains a list
+of sample projects you can try out.
 
 ![Hello World](docs/hello_world_screenshot.png)
 
+## Compatibility
+
+This library is designed for the Arduino Nano BLE Sense 33 board. The framework
+code for running machine learning models should be compatible with most Arm Cortex
+M-based boards, such as the Raspberry Pi Pico, but the code to access peripherals
+like microphones, cameras, and accelerometers is specific to the Nano.
+
+## License
+
+This code is made available under the Apache 2 license.
+
+## Contributing
+
+Forks of this library are welcome and encouraged. If you have bug reports or
+fixes to contribute, the source of this code is at [https:://github.com/tensorflow/tflite-micro](github.com/tensorflow/tflite-micro)
+and all issues and pull requests should be directed there.
+
+The code here is created through an automatic project generation process from
+that source of truth, since it's cross-platform and needs to be modified to
+work within the Arduino IDE.

--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ repository, you can clone the repo into `~/Arduino/libraries` and then open up t
 TFLM examples in your Arduino IDE.
 
 ![Hello World](docs/hello_world_screenshot.png)
+

--- a/examples/micro_speech/arduino_audio_provider.cpp
+++ b/examples/micro_speech/arduino_audio_provider.cpp
@@ -53,7 +53,7 @@ volatile int32_t g_latest_audio_timestamp = 0;
 
 void CaptureSamples() {
   // This is how many bytes of new data we have each time this is called
-  const int number_of_samples = DEFAULT_PDM_BUFFER_SIZE;
+  const int number_of_samples = DEFAULT_PDM_BUFFER_SIZE / 2;
   // Calculate what timestamp the last audio sample represents
   const int32_t time_in_ms =
       g_latest_audio_timestamp +


### PR DESCRIPTION
Fix to error in audio sample rate first flagged in https://github.com/tensorflow/tensorflow/pull/45878. That change was unable to be merged because it included multiple fixes, but this more-limited PR should solve at least this problem.

I've tested with a board myself, and it has been used extensively by the EdX students too.
