### PR TITLE
setting up mergify for testing

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,17 @@
+queue_rules:
+  - name: default
+    conditions:
+      - label=ci:mergify
+    
+   
+pull_request_rules:
+  - name: push to default merge queue
+    conditions:
+      - base=main
+      - label=ci:mergify
+      - check-success=cla/google
+    actions:
+      queue:
+        name: default
+        require_branch_protection: true
+        method: squash


### PR DESCRIPTION
Set up a test mergify queue. It is configured to test for cla/google status in the mergify config. For this to work as advertised, this test must be removed from the branch protection rules or it will stop queuing from working properly.