### PR TITLE
Implement mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,17 +1,25 @@
 queue_rules:
   - name: default
     conditions:
-      - label=ci:mergify
+      - base=main
+      - label=ci:ready_to_merge
     
    
 pull_request_rules:
   - name: push to default merge queue
     conditions:
       - base=main
-      - label=ci:mergify
-      - check-success=cla/google
+      - label=ci:ready_to_merge
     actions:
       queue:
         name: default
         require_branch_protection: true
         method: squash
+
+  - name: remove ci:ready_to_merge label
+    conditions:
+      - merged
+    actions:
+      label:
+        remove:
+          - ci:ready_to_merge

--- a/.github/workflows/apply_cirun.yml
+++ b/.github/workflows/apply_cirun.yml
@@ -1,0 +1,19 @@
+on:
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  apply-label:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'ci:ready_to_merge')
+    steps:
+      - uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.TFLM_BOT_REPO_TOKEN }} 
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['ci:run']
+            })


### PR DESCRIPTION
When ci:ready_to_merge tag is added to a PR, the PR will be added to the mergify queue. This should only be done after a PR has passed the tests using the ci:run tag.

apply_cirun.yml reapplies the ci:run tag to run tests when multiple PRs are in the mergify queue. Each PR in queue merged into following PRs resets the tags, and will cause the queue to stall waiting on tests to run.

This PR assumes this repo has access to TFLM_BOT_REPO_TOKEN, which appears to be the case, but I don't have access to check.

BUG=https://issuetracker.google.com/issues/228103530