### PR TITLE
testing skipped test merge bug

### DIFF
--- a/.github/deleteme2.txt
+++ b/.github/deleteme2.txt
@@ -1,0 +1,1 @@
+File to test a hitch in test machinery. Delete it.


### PR DESCRIPTION
This is a second PR adding a pointless file to try to recreate an apparent bug in the ci machinery where a skipped required test didn't prevent the merge button from being active. Will first create as a draft and then open for review as in the original case.

BUG=https://issuetracker.google.com/issues/233865150