### PR TITLE
Fix repo sync/ci failure

### DIFF
--- a/src/peripherals/peripherals.h
+++ b/src/peripherals/peripherals.h
@@ -19,6 +19,10 @@ limitations under the License.
 #ifdef ARDUINO
 #include <Arduino.h>
 #include <Wire.h>
+
+// Temporary fix, see buganizer #268498682, arduino-examples issue #169
+#undef abs
+
 #else  // ARDUINO
 #error "unsupported framework"
 #endif  // ARDUINO


### PR DESCRIPTION
@tensorflow/micro

undefine the abs() macro from Arduino.h as it conflicts with micro_mutable_op_resolver.h and its descendant includes

bug=fixes Fix problem with daily sync #169